### PR TITLE
a one-liner to enable the use of the RNN parser model

### DIFF
--- a/corenlp.py
+++ b/corenlp.py
@@ -134,6 +134,7 @@ class StanfordCoreNLP(object):
         """
         jars = ["stanford-corenlp-3.4.1.jar",
                 "stanford-corenlp-3.4.1-models.jar",
+                "ejml-0.23.jar",  # required by RNN model
                 "joda-time.jar",
                 "xom.jar",
                 "jollyday.jar"]

--- a/default.properties
+++ b/default.properties
@@ -31,6 +31,9 @@ annotators = tokenize, ssplit, pos, lemma, ner, parse, dcoref
 #nfl.entity.model =  /scr/nlp/data/ldc/LDC2009E112/Machine_Reading_P1_NFL_Scoring_Training_Data_V1.2/models/nfl_entity_model.ser
 #printable.relation.beam = 20
 
+#use the RNN parser
+#parse.model = edu/stanford/nlp/models/lexparser/englishRNN.ser.gz
+
 #parser.model = /u/nlp/data/lexparser/englishPCFG.ser.gz
 
 #srl.verb.args=/u/kristina/srl/verbs.core_args


### PR DESCRIPTION
added ejml to the list of jars so that it is available for the RNN parser, also added a #-prefixed line to default.properties that can be used to choose the RNN model over the default PCFG

```
modified:   corenlp.py
modified:   default.properties
```
