### PR TITLE
Fixing the attribute error on tree

### DIFF
--- a/client.py
+++ b/client.py
@@ -15,5 +15,5 @@ result = nlp.parse("Hello world!  It is so beautiful.")
 pprint(result)
 
 from nltk.tree import Tree
-tree = Tree.parse(result['sentences'][0]['parsetree'])
+tree = Tree.fromstring(result['sentences'][0]['parsetree'])
 pprint(tree)


### PR DESCRIPTION
Existing behaviour  :
Traceback (most recent call last):
  File "client.py", line 18, in <module>
    tree = Tree.parse(result['sentences'][0]['parsetree'])
AttributeError: type object 'Tree' has no attribute 'parse'

Fixing the parsing of tree . Output after the fix:

Tree('ROOT', [Tree('S', [Tree('NP', [Tree('PRP', ['It'])]), Tree('VP', [Tree('VBZ', ['is']), Tree('ADJP', [Tree('RB', ['so']), Tree('JJ', ['beautiful'])])]), Tree('.', ['.'])])])
